### PR TITLE
Auto convert USDC to USD on Coinbase Pro

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "coinbasepro-python"]
+	path = coinbasepro_python
+	url = git@github.com:freenancial/coinbasepro-python.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## Dollar Cost Averaging Bitcoin on CoinbasePro
 
+After checking out this repo, please run:
+
+`git submodule update --init`
+
 To start Bitcoin DCA:
 
 `./start_dca.sh`

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 ## Dollar Cost Averaging Bitcoin on CoinbasePro
 
-To install this tool:
-
-`./install.sh`
-
 To start Bitcoin DCA:
 
 `./start_dca.sh`
@@ -14,7 +10,6 @@ To stop Bitcoin DCA:
 
 `./stop_dca.sh`
 
-To adjust the amount and frequency of Bitcoin DCA:
+To adjust the configuration of Bitcoin DCA:
 
 Modify `config.py`
-

--- a/buy_bitcoin.py
+++ b/buy_bitcoin.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from config import DCA_USD_AMOUNT, DCA_FREQUENCY, USE_USDC, AUTO_WITHDRAWL, WITHDRAW_THRESHOLD, BTC_ADDRESSES
+from config import DCA_USD_AMOUNT, DCA_FREQUENCY, AUTO_WITHDRAWL, WITHDRAW_THRESHOLD, BTC_ADDRESSES
 from coinbase_pro import CoinbasePro
 
 import os

--- a/buy_bitcoin.py
+++ b/buy_bitcoin.py
@@ -9,13 +9,14 @@ import datetime
 API_KEY = os.environ['API_KEY']
 API_SECRET = os.environ['API_SECRET']
 PASSPHRASE = os.environ['PASSPHRASE']
-coinbase_pro = CoinbasePro(API_KEY, API_SECRET, PASSPHRASE, use_usdc=USE_USDC)
+coinbase_pro = CoinbasePro(API_KEY, API_SECRET, PASSPHRASE)
 
 cur_btc_address_index = 0
 
 while True:
   coinbase_pro.refreshBalance()
-  coinbase_pro.depositFromCoinbase(DCA_USD_AMOUNT)
+  coinbase_pro.depositUSDCFromCoinbase(DCA_USD_AMOUNT)
+  coinbase_pro.convertUSDCToUSD(DCA_USD_AMOUNT)
   coinbase_pro.buyBitcoin(DCA_USD_AMOUNT)
 
   if AUTO_WITHDRAWL and cur_btc_address_index < len(BTC_ADDRESSES) and coinbase_pro.getBitcoinWorth() >= WITHDRAW_THRESHOLD:

--- a/coinbase_pro.py
+++ b/coinbase_pro.py
@@ -2,15 +2,13 @@ import cbpro
 import time
 
 class CoinbasePro:
-  def __init__(self, api_key, api_secret, passphrase, use_usdc):
+  def __init__(self, api_key, api_secret, passphrase):
     self.auth_client = cbpro.AuthenticatedClient(api_key, api_secret, passphrase)
-    self.use_usdc = use_usdc
 
   def refreshBalance(self):
     self.coinbase_pro_accounts = self.auth_client.get_accounts()
     self.coinbase_accounts = self.auth_client.get_coinbase_accounts()
 
-    self.coinbase_usd_account = self.getCoinbaseAccount('USD')
     self.coinbase_usdc_account = self.getCoinbaseAccount('USDC')
     self.coinbase_pro_usd_account = self.getCoinbaseProAccount('USD')
     self.coinbase_pro_usdc_account = self.getCoinbaseProAccount('USDC')
@@ -25,21 +23,21 @@ class CoinbasePro:
 
   def showBalance(self):
     print()
-    if not self.use_usdc:
-      print("Coinbase USD balance: {:.2f}".format(float(self.coinbase_usd_account['balance'])))
-      print("Coinbase Pro USD balance: {:.2f}".format(float(self.coinbase_pro_usd_account['balance'])))
-    else:
-      print("Coinbase USDC balance: {:.2f}".format(float(self.coinbase_usdc_account['balance'])))
-      print("Coinbase Pro USDC balance: {:.2f}".format(float(self.coinbase_pro_usdc_account['balance'])))
+    print("Coinbase USDC balance: {:.2f}".format(float(self.coinbase_usdc_account['balance'])))
+    print("Coinbase Pro USDC balance: {:.2f}".format(float(self.coinbase_pro_usdc_account['balance'])))
+    print("Coinbase Pro USD balance: {:.2f}".format(float(self.coinbase_pro_usd_account['balance'])))
     print("Coinbase Pro BTC balance: {}".format(float(self.coinbase_pro_btc_account['balance'])))
     print()
 
-  def depositFromCoinbase(self, amount):
-    currency = 'USD' if not self.use_usdc else 'USDC'
-    account_id = self.coinbase_usd_account['id'] if not self.use_usdc else self.coinbase_usdc_account['id']
+  def depositUSDCFromCoinbase(self, amount):
+    print(f"Depoisting ${amount} USDC from Coinabase ...")
+    deposit_result = self.auth_client.coinbase_deposit(amount, 'USDC', self.coinbase_usdc_account['id'])
+    print(deposit_result)
+    self.refreshBalance()
 
-    print(f"Depoisting ${amount} ${currency} from Coinabase to Coinbase Pro...")
-    deposit_result = self.auth_client.coinbase_deposit(amount, currency, account_id)
+  def convertUSDCToUSD(self, amount):
+    print(f"Converting ${amount} USDC to USD ...")
+    deposit_result = self.auth_client.coinbase_deposit(amount, 'USDC', self.coinbase_usdc_account['id'])
     print(deposit_result)
     self.refreshBalance()
 

--- a/coinbase_pro.py
+++ b/coinbase_pro.py
@@ -1,4 +1,4 @@
-import cbpro
+import coinbasepro_python.cbpro
 import time
 
 class CoinbasePro:

--- a/config.py
+++ b/config.py
@@ -1,9 +1,7 @@
 # How many dollar of Bitcoin you want to buy each time.
-DCA_USD_AMOUNT = 10
+DCA_USD_AMOUNT = 5
 # How frequent you want to buy Bitcoin in seconds.
-DCA_FREQUENCY = 7200
-# If set to True, bitcoin-dca will use USDC instead of USD to purchase Bitcoin.
-USE_USDC = True
+DCA_FREQUENCY = 4320
 
 # If set to True, bitcoin-dca will auto withdraw Bitcoin to configured BTC_ADDRESSES
 # once the Bitcoin worth of the account is above WITHDRAW_THRESHOLD.

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-python3 -m pip install cbpro

--- a/start_dca.sh
+++ b/start_dca.sh
@@ -12,5 +12,5 @@ echo "Your Coinbase Pro API passphrase:"
 read -s PASSPHRASE
 export PASSPHRASE
 
-nohup python3 -u ./buy_bitcoin.py >> btc_dca.log &
+PYTHONPATH="./coinbasepro_python" nohup python3 -u ./buy_bitcoin.py >> btc_dca.log &
 echo "Bitcoin DCA started, check 'btc_dca.log' for log data."


### PR DESCRIPTION
Remove `USE_USDC` config.

Instead, always deposit "USDC" from Coinbase to Coinbase Pro, and convert "USDC" to "USD" on Coinbase Pro before buying Bitcoin.