### PR TITLE
Ignore `order_result` parse error

### DIFF
--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -112,9 +112,14 @@ class CoinbasePro:
         order_result = self.auth_client.place_market_order(
             product_id, "buy", funds=usd_amount
         )
-        while not order_result["settled"]:
-            time.sleep(1)
-            order_result = self.auth_client.get_order(order_result["id"])
+        Logger.info(f"order_result: {order_result}")
+        try:
+            while not order_result["settled"]:
+                time.sleep(1)
+                order_result = self.auth_client.get_order(order_result["id"])
+        except Exception:  # pylint: disable=broad-except
+            Logger.error(f"Unable to got or parse order_result: {order_result}")
+
         self.printOrderResult(order_result)
         self.db_manager.saveBuyTransaction(
             date=order_result["done_at"],

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -123,7 +123,7 @@ class CoinbasePro:
                 size=order_result["filled_size"],
             )
         except Exception:  # pylint: disable=broad-except
-            Logger.error(f"Unable to got or parse order_result: {order_result}")
+            Logger.error(f"Unable to fetch or parse order_result: {order_result}")
         time.sleep(5)
 
     def usdc_balance(self):

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -112,20 +112,18 @@ class CoinbasePro:
         order_result = self.auth_client.place_market_order(
             product_id, "buy", funds=usd_amount
         )
-        Logger.info(f"order_result: {order_result}")
         try:
             while not order_result["settled"]:
                 time.sleep(1)
                 order_result = self.auth_client.get_order(order_result["id"])
+            self.printOrderResult(order_result)
+            self.db_manager.saveBuyTransaction(
+                date=order_result["done_at"],
+                cost=round(float(order_result["specified_funds"]), 2),
+                size=order_result["filled_size"],
+            )
         except Exception:  # pylint: disable=broad-except
             Logger.error(f"Unable to got or parse order_result: {order_result}")
-
-        self.printOrderResult(order_result)
-        self.db_manager.saveBuyTransaction(
-            date=order_result["done_at"],
-            cost=round(float(order_result["specified_funds"]), 2),
-            size=order_result["filled_size"],
-        )
         time.sleep(5)
 
     def usdc_balance(self):


### PR DESCRIPTION
When parsing `order_result` failed, it doesn't mean the bitcoin purchase had been failed.
Retrying bitcoin buy when the parsing failed may cause incorrect re-purchase of bitcoin.