### PR TITLE
Allow setting a min USDC balance

### DIFF
--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -22,9 +22,9 @@ class CoinbasePro:
 
     def refresh(self):
         self.accounts = self.auth_client.get_accounts()
-        time.sleep(1)
+        time.sleep(5)
         self.coinbase_accounts = self.auth_client.get_coinbase_accounts()
-        time.sleep(1)
+        time.sleep(5)
 
     def getAccount(self, currency):
         try:
@@ -115,7 +115,7 @@ class CoinbasePro:
         )
         try:
             while not order_result["settled"]:
-                time.sleep(1)
+                time.sleep(5)
                 order_result = self.auth_client.get_order(order_result["id"])
             self.printOrderResult(order_result)
             self.db_manager.saveBuyTransaction(

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -7,6 +7,7 @@ import time
 import _path_init  # pylint: disable=unused-import
 import db_manager
 from coinbasepro_python import cbpro
+from config import MIN_USDC_BALANCE
 from logger import Logger
 
 Account = collections.namedtuple("Account", "id balance")
@@ -92,8 +93,8 @@ class CoinbasePro:
         self.refresh()
 
         amount = math.ceil(amount * 100) / 100
-        if self.usdc_balance() < amount:
-            self.depositUSDCFromCoinbase(amount - self.usdc_balance())
+        if self.usdc_balance() < amount + MIN_USDC_BALANCE:
+            self.depositUSDCFromCoinbase(amount + MIN_USDC_BALANCE - self.usdc_balance())
 
         Logger.info(f"Converting ${amount} USDC to USD ...")
         self.auth_client.convert_stablecoin(amount, "USDC", "USD")

--- a/bitcoin_dca/config.py
+++ b/bitcoin_dca/config.py
@@ -5,6 +5,9 @@ DCA_USD_AMOUNT = 5
 # How frequent you want to buy Bitcoin in seconds.
 DCA_FREQUENCY = 4320
 
+# The minimum usdc balance to be kept on Coinbase Pro
+MIN_USDC_BALANCE = 0
+
 # If set to True, bitcoin-dca will auto withdraw Bitcoin once it has bought Bitcoin
 # WITHDRAW_EVERY_X_BUY times.
 AUTO_WITHDRAWL = False


### PR DESCRIPTION
Sometimes USDC got frozen on Coinbase Pro, it seems to be a bug on the Coinbase Pro's server.
This is not an ideal solution, but allows the script to continue running when such an issue occurred.