### PR TITLE
Check bitcoin_dca  process before killing it

### DIFF
--- a/scripts/stop_dca.sh
+++ b/scripts/stop_dca.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-
-kill $(ps aux|grep "[b]itcoin_dca.py" |  awk '{print $2}')
+dca_pid=$(pgrep -f '[b]itcoin_dca.py')
+[ -n "$dca_pid" ] && kill $dca_pid || true


### PR DESCRIPTION
Right now we don't check if the `bitcoin_dca` process before killing it, so we will see error message `kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]` if no process is running. This will actually happens on first time running `make start_dca`. This PR makes sure checking the process before killing it.

Also, we will use `pgrep` which is simpler than the pipe chain. `pgrep -f` will match the full argument list, since the process name is actually `python3`, not `bitcoin_dca`.