### PR TITLE
Skip Robinhood buy if not configured and improve the logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ setup: init
 	. venv/bin/activate && ./bitcoin_dca/setup.py
 
 start_dca:
-	./scripts/stop_dca.sh || true
-	./scripts/start_dca.sh
+	./scripts/stop_dca.sh && ./scripts/start_dca.sh
 
 stop_dca:
 	./scripts/stop_dca.sh

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -42,7 +42,6 @@ class BitcoinDCA:
                 default_config.withdraw_beginning_address,
             )
         self.db_manager = DBManager()
-        self.next_buy_datetime = self.calcFirstBuyTime()
         self.next_robinhood_buy_datetime = self.calcRobinhoodFirstBuyTime()
         if is_coinbase:
             self.coinbase_pro = self.newCoinbaseProClient()
@@ -148,11 +147,15 @@ class BitcoinDCA:
     def startCoinbaseDCA(self):
         Logger.info("----------------------")
         Logger.info("----------------------")
-        Logger.info("Coinbase DCA started\n")
+        Logger.info("Coinbase DCA started")
+
+        Logger.info("")
+        self.next_buy_datetime = self.calcFirstBuyTime()
         Logger.info(
             f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
-            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase...\n"
+            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase..."
         )
+        Logger.info("")
         self.coinbase_pro.showBalance()
 
         while True:

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -68,6 +68,9 @@ class BitcoinDCA:
             return datetime.datetime.now()
 
         last_buy_datetime = DBManager.convertOrderDatetime(last_buy_order_datetime)
+        Logger.info(
+            f"Last Coinbase buy order was at: {last_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')}\n"
+        )
         return max(
             datetime.datetime.now(),
             last_buy_datetime + datetime.timedelta(0, default_config.dca_frequency),

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -235,7 +235,8 @@ def robinhoodDCA():
 
 
 if __name__ == "__main__":
-    _thread.start_new_thread(robinhoodDCA, ())
+    if default_config.robinhood_dca_usd_amount > 0:
+        _thread.start_new_thread(robinhoodDCA, ())
     time.sleep(5)
     coinbase_dca = BitcoinDCA(True, os.environ["ENCRYPTION_PASS"])
     coinbase_dca.startCoinbaseDCA()

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -44,14 +44,15 @@ class BitcoinDCA:
         self.db_manager = DBManager()
         self.next_robinhood_buy_datetime = self.calcRobinhoodFirstBuyTime()
         if is_coinbase:
+            Logger.info("\n")
+            Logger.info("----------------------")
+            Logger.info("----------------------")
+            Logger.info("Coinbase DCA started")
+            Logger.info("")
             self.coinbase_pro = self.newCoinbaseProClient()
             self.next_buy_datetime = self.calcFirstBuyTime()
 
     def newCoinbaseProClient(self):
-        Logger.info("----------------------")
-        Logger.info("----------------------")
-        Logger.info("Coinbase DCA started")
-
         return CoinbasePro(
             self.secrets["api_key"],
             self.secrets["api_secret"],
@@ -151,13 +152,12 @@ class BitcoinDCA:
         )
 
     def startCoinbaseDCA(self):
-        Logger.info("")
+        self.coinbase_pro.showBalance()
         Logger.info(
             f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
             f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase..."
         )
         Logger.info("")
-        self.coinbase_pro.showBalance()
 
         while True:
             self.waitForNextBuyTime()

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -44,21 +44,13 @@ class BitcoinDCA:
         self.db_manager = DBManager()
         self.next_robinhood_buy_datetime = self.calcRobinhoodFirstBuyTime()
         if is_coinbase:
-            self.next_buy_datetime = self.calcFirstBuyTime()
             self.coinbase_pro = self.newCoinbaseProClient()
+            self.next_buy_datetime = self.calcFirstBuyTime()
 
     def newCoinbaseProClient(self):
         Logger.info("----------------------")
         Logger.info("----------------------")
         Logger.info("Coinbase DCA started")
-
-        Logger.info("")
-        Logger.info(
-            f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
-            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase..."
-        )
-        Logger.info("")
-        self.coinbase_pro.showBalance()
 
         return CoinbasePro(
             self.secrets["api_key"],
@@ -159,6 +151,14 @@ class BitcoinDCA:
         )
 
     def startCoinbaseDCA(self):
+        Logger.info("")
+        Logger.info(
+            f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase..."
+        )
+        Logger.info("")
+        self.coinbase_pro.showBalance()
+
         while True:
             self.waitForNextBuyTime()
 

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -43,6 +43,10 @@ class BitcoinDCA:
             )
         self.db_manager = DBManager()
         self.next_buy_datetime = self.calcFirstBuyTime()
+        Logger.info(
+            f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase...\n"
+        )
         self.next_robinhood_buy_datetime = self.calcRobinhoodFirstBuyTime()
         if is_coinbase:
             self.coinbase_pro = self.newCoinbaseProClient()
@@ -57,6 +61,10 @@ class BitcoinDCA:
 
     def calcFirstBuyTime(self):
         last_buy_order_datetime = self.db_manager.getLastBuyOrderDatetime()
+        Logger.info(
+            f"Last coinbase buy order was at: {last_buy_order_datetime.strftime('%Y-%m-%d %H:%M:%S')}\n"
+        )
+
         # If we have no buy recored, we execute a buy order immediately.
         if not last_buy_order_datetime:
             return datetime.datetime.now()

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -62,8 +62,9 @@ class BitcoinDCA:
 
         last_buy_datetime = DBManager.convertOrderDatetime(last_buy_order_datetime)
         Logger.info(
-            f"Last Coinbase buy order was at: {last_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"Last Coinbase buy order was at: {last_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')}"
         )
+        Logger.info("")
         return max(
             datetime.datetime.now(),
             last_buy_datetime + datetime.timedelta(0, default_config.dca_frequency),

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -151,13 +151,13 @@ class BitcoinDCA:
         )
 
     def startCoinbaseDCA(self):
-        print("----------------------")
-        print("----------------------")
-        Logger.info("Coinbase DCA started\n")
-
         Logger.info("----------------------")
         Logger.info("----------------------")
         Logger.info("Coinbase DCA started\n")
+        Logger.info(
+            f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase...\n"
+        )
         self.coinbase_pro.showBalance()
 
         while True:

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -44,9 +44,22 @@ class BitcoinDCA:
         self.db_manager = DBManager()
         self.next_robinhood_buy_datetime = self.calcRobinhoodFirstBuyTime()
         if is_coinbase:
+            self.next_buy_datetime = self.calcFirstBuyTime()
             self.coinbase_pro = self.newCoinbaseProClient()
 
     def newCoinbaseProClient(self):
+        Logger.info("----------------------")
+        Logger.info("----------------------")
+        Logger.info("Coinbase DCA started")
+
+        Logger.info("")
+        Logger.info(
+            f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase..."
+        )
+        Logger.info("")
+        self.coinbase_pro.showBalance()
+
         return CoinbasePro(
             self.secrets["api_key"],
             self.secrets["api_secret"],
@@ -146,19 +159,6 @@ class BitcoinDCA:
         )
 
     def startCoinbaseDCA(self):
-        Logger.info("----------------------")
-        Logger.info("----------------------")
-        Logger.info("Coinbase DCA started")
-
-        Logger.info("")
-        self.next_buy_datetime = self.calcFirstBuyTime()
-        Logger.info(
-            f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
-            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase..."
-        )
-        Logger.info("")
-        self.coinbase_pro.showBalance()
-
         while True:
             self.waitForNextBuyTime()
 

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -43,10 +43,6 @@ class BitcoinDCA:
             )
         self.db_manager = DBManager()
         self.next_buy_datetime = self.calcFirstBuyTime()
-        Logger.info(
-            f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
-            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase...\n"
-        )
         self.next_robinhood_buy_datetime = self.calcRobinhoodFirstBuyTime()
         if is_coinbase:
             self.coinbase_pro = self.newCoinbaseProClient()
@@ -61,8 +57,6 @@ class BitcoinDCA:
 
     def calcFirstBuyTime(self):
         last_buy_order_datetime = self.db_manager.getLastBuyOrderDatetime()
-        Logger.info(f"Last coinbase buy order was at: {last_buy_order_datetime}\n")
-
         # If we have no buy recored, we execute a buy order immediately.
         if not last_buy_order_datetime:
             return datetime.datetime.now()

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -93,7 +93,8 @@ class BitcoinDCA:
         # Skip buying bitcoin if ahr999 index is above 5.0
         try:
             ahr999_index_value = ahr999_index.getCurrentIndexValue()
-            Logger.info(f"ahr999_index: {ahr999_index_value}\n")
+            Logger.info(f"ahr999_index: {ahr999_index_value}")
+            Logger.info("")
             if ahr999_index_value > 5.0:
                 Logger.info("ahr999_index is over 5.0")
                 Logger.info("Skip this round of Bitcoin purchase")

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -61,9 +61,7 @@ class BitcoinDCA:
 
     def calcFirstBuyTime(self):
         last_buy_order_datetime = self.db_manager.getLastBuyOrderDatetime()
-        Logger.info(
-            f"Last coinbase buy order was at: {last_buy_order_datetime.strftime('%Y-%m-%d %H:%M:%S')}\n"
-        )
+        Logger.info(f"Last coinbase buy order was at: {last_buy_order_datetime}\n")
 
         # If we have no buy recored, we execute a buy order immediately.
         if not last_buy_order_datetime:

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -178,7 +178,8 @@ class CoinbasePro:
         )
         Logger.info(f"  Price: \t{ price }")
         Logger.info(f"  Fee: \t{ order_result['fill_fees'] }")
-        Logger.info(f"  Date: \t{ order_result['done_at'] }\n")
+        Logger.info(f"  Date: \t{ order_result['done_at'] }")
+        Logger.info("")
 
     @staticmethod
     def convertRawAccount(raw_account):

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -131,10 +131,13 @@ class CoinbasePro:
         order_result = self.auth_client.place_market_order(
             product_id, "buy", funds=usd_amount
         )
+        Logger.info(f"order_result: {order_result}")
+
         try:
             while not order_result["settled"]:
                 time.sleep(5)
                 order_result = self.auth_client.get_order(order_result["id"])
+                Logger.info(f"order_result: {order_result}")
             self.printOrderResult(order_result)
             self.db_manager.saveBuyTransaction(
                 date=order_result["done_at"],

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -82,7 +82,8 @@ class CoinbasePro:
         Logger.info("  Coinbase: ${:.2f}".format(self.coinbase_usdc_account.balance))
         Logger.info("  USDC: ${:.2f}".format(math.floor(self.usdc_balance * 100) / 100))
         Logger.info("  USD: ${:.2f}".format(math.floor(self.usd_balance * 100) / 100))
-        Logger.info("  BTC: ₿{}\n".format(self.btc_account.balance))
+        Logger.info("  BTC: ₿{}".format(self.btc_account.balance))
+        Logger.info("")
 
     @property
     def unwithdrawn_buys_count(self):
@@ -141,7 +142,9 @@ class CoinbasePro:
                 size=order_result["filled_size"],
             )
         except Exception as error:  # pylint: disable=broad-except
-            Logger.error(f"Buy Bitcoin failed, error: {error}; order_result: {order_result}")
+            Logger.error(
+                f"Buy Bitcoin failed, error: {error}; order_result: {order_result}"
+            )
         time.sleep(5)
 
     def withdrawBitcoin(self, amount, address):

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -97,7 +97,8 @@ class CoinbasePro:
         result = self.auth_client.coinbase_deposit(
             amount, "USDC", self.coinbase_usdc_account.id
         )
-        Logger.info(f"  {result}\n")
+        Logger.info(f"  {result}")
+        Logger.info("")
         time.sleep(5)
 
     def convertUSDCToUSD(self, amount):
@@ -111,7 +112,8 @@ class CoinbasePro:
 
         Logger.info(f"Converting ${amount} USDC to USD ...")
         result = self.auth_client.convert_stablecoin(amount, "USDC", "USD")
-        Logger.info(f"  {result}\n")
+        Logger.info(f"  {result}")
+        Logger.info("")
         time.sleep(5)
 
     def buyBitcoin(self, usd_amount):
@@ -131,13 +133,14 @@ class CoinbasePro:
         order_result = self.auth_client.place_market_order(
             product_id, "buy", funds=usd_amount
         )
-        Logger.info(f"order_result: {order_result}")
+        Logger.info(f"  order_result: {order_result}")
 
         try:
+            order_id = order_result["id"]
             while not order_result["settled"]:
                 time.sleep(5)
-                order_result = self.auth_client.get_order(order_result["id"])
-                Logger.info(f"order_result: {order_result}")
+                order_result = self.auth_client.get_order(order_id)
+                Logger.info(f"  order_result: {order_result}")
             self.printOrderResult(order_result)
             self.db_manager.saveBuyTransaction(
                 date=order_result["done_at"],
@@ -153,7 +156,8 @@ class CoinbasePro:
     def withdrawBitcoin(self, amount, address):
         Logger.info(f"Withdrawing ₿{amount} Bitcoin to address {address} ...")
         result = self.auth_client.crypto_withdraw(amount, "BTC", address)
-        Logger.info(f"  {result}\n")
+        Logger.info(f"  {result}")
+        Logger.info("")
         self.db_manager.updateWithdrawAddressForBuyOrders(address)
 
     def getBitcoinWorth(self):


### PR DESCRIPTION
1. Skip the launching of Robinhood Buy thread if not configured.
2. Show the time of the last Coinbase buy during launching.
3. After the improvement of `stop_dca.sh`, #33 , we no longer need the `|| true` in Makefile.
4. Save the Order ID when checking for order status, and add more logging for debugging "order result querying"
