### PR TITLE
Encrypt withdrawal address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,12 @@
 
 init:
 	./scripts/init.sh
-
-setup: init
 	cp config_template.ini config.ini
+
+update_secret:
 	. venv/bin/activate && ./bitcoin_dca/setup.py
+
+setup: init update_secret
 
 start_dca:
 	./scripts/stop_dca.sh && ./scripts/start_dca.sh

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ init:
 update_secrets:
 	. venv/bin/activate && ./bitcoin_dca/setup.py
 
-setup: init update_secret
+setup: init update_secrets
 
 start_dca:
 	./scripts/stop_dca.sh && ./scripts/start_dca.sh

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ init:
 	./scripts/init.sh
 	cp config_template.ini config.ini
 
-update_secret:
+update_secrets:
 	. venv/bin/activate && ./bitcoin_dca/setup.py
 
 setup: init update_secret

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -38,8 +38,7 @@ class BitcoinDCA:
 
         if is_coinbase and default_config.withdraw_every_x_buy:
             self.address_selector = AddressSelector(
-                default_config.withdraw_master_public_key,
-                default_config.withdraw_beginning_address,
+                self.secrets["master_public_key"], self.secrets["beginning_address"],
             )
         self.db_manager = DBManager()
         self.next_robinhood_buy_datetime = self.calcRobinhoodFirstBuyTime()

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -97,7 +97,7 @@ class CoinbasePro:
         result = self.auth_client.coinbase_deposit(
             amount, "USDC", self.coinbase_usdc_account.id
         )
-        Logger.info(f"  {result}")
+        Logger.debug(f"  {result}")
         Logger.info("")
         time.sleep(5)
 
@@ -112,7 +112,7 @@ class CoinbasePro:
 
         Logger.info(f"Converting ${amount} USDC to USD ...")
         result = self.auth_client.convert_stablecoin(amount, "USDC", "USD")
-        Logger.info(f"  {result}")
+        Logger.debug(f"  {result}")
         Logger.info("")
         time.sleep(5)
 
@@ -133,14 +133,14 @@ class CoinbasePro:
         order_result = self.auth_client.place_market_order(
             product_id, "buy", funds=usd_amount
         )
-        Logger.info(f"  order_result: {order_result}")
+        Logger.debug(f"  order_result: {order_result}")
 
         try:
             order_id = order_result["id"]
             while not order_result["settled"]:
                 time.sleep(5)
                 order_result = self.auth_client.get_order(order_id)
-                Logger.info(f"  order_result: {order_result}")
+                Logger.debug(f"  order_result: {order_result}")
             self.printOrderResult(order_result)
             self.db_manager.saveBuyTransaction(
                 date=order_result["done_at"],

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -137,7 +137,7 @@ class CoinbasePro:
 
         try:
             order_id = order_result["id"]
-            while not order_result["settled"]:
+            while not order_result.get("settled"):
                 time.sleep(5)
                 order_result = self.auth_client.get_order(order_id)
                 Logger.debug(f"  order_result: {order_result}")

--- a/bitcoin_dca/config.py
+++ b/bitcoin_dca/config.py
@@ -44,14 +44,6 @@ class Config:
         return self.config["AUTO_WITHDRAWL"].getint("WITHDRAW_EVERY_X_BUY")
 
     @property
-    def withdraw_master_public_key(self):
-        return self.config["AUTO_WITHDRAWL"].get("MASTER_PUBLIC_KEY")
-
-    @property
-    def withdraw_beginning_address(self):
-        return self.config["AUTO_WITHDRAWL"].get("BEGINNING_ADDRESS")
-
-    @property
     def notification_gmail_user_name(self):
         return self.config["NOTIFICATION"].get("GMAIL_USER_NAME")
 

--- a/bitcoin_dca/secret.py
+++ b/bitcoin_dca/secret.py
@@ -112,7 +112,7 @@ class Secret:
         if not encryption_pass:
             encryption_pass = getpass.getpass("Password for unlocking secrets: ")
         with open("bitcoin_dca.secrets", "r") as f:
-            secret_version = f.readline()
+            secret_version = f.readline().strip()
             if secret_version != SECRET_VERSION:
                 Logger.error(
                     f"Wrong secret version. Expected: '{SECRET_VERSION}'; Found: '{secret_version}'"
@@ -123,15 +123,15 @@ class Secret:
             salt_b64_str = f.readline()
             key = Secret.generateEncryptionKey(encryption_pass, salt_b64_str)
             try:
-                api_key = Secret.decrypt(key, f.readline())
-                api_secret = Secret.decrypt(key, f.readline())
-                passphrase = Secret.decrypt(key, f.readline())
-                master_public_key = Secret.decrypt(key, f.readline())
-                beginning_address = Secret.decrypt(key, f.readline())
-                gmail_password = Secret.decrypt(key, f.readline())
-                robinhood_user = Secret.decrypt(key, f.readline())
-                robinhood_password = Secret.decrypt(key, f.readline())
-                robinhood_totp = Secret.decrypt(key, f.readline())
+                api_key = Secret.decrypt(key, f.readline()).strip()
+                api_secret = Secret.decrypt(key, f.readline()).strip()
+                passphrase = Secret.decrypt(key, f.readline()).strip()
+                master_public_key = Secret.decrypt(key, f.readline()).strip()
+                beginning_address = Secret.decrypt(key, f.readline()).strip()
+                gmail_password = Secret.decrypt(key, f.readline()).strip()
+                robinhood_user = Secret.decrypt(key, f.readline()).strip()
+                robinhood_password = Secret.decrypt(key, f.readline()).strip()
+                robinhood_totp = Secret.decrypt(key, f.readline()).strip()
                 Secret.secrets_dict = {
                     "api_key": api_key,
                     "api_secret": api_secret,

--- a/bitcoin_dca/secret.py
+++ b/bitcoin_dca/secret.py
@@ -65,9 +65,9 @@ class Secret:
         robinhood_totp = ""
 
         if Secret.answeredYes("DCA with Coinbase Pro? (y/n): "):
+            passphrase = getpass.getpass("Your Coinbase Pro API passphrase: ")
             api_key = getpass.getpass("Your Coinbase Pro API key: ")
             api_secret = getpass.getpass("Your Coinbase Pro API secret: ")
-            passphrase = getpass.getpass("Your Coinbase Pro API passphrase: ")
             print("")
 
             if Secret.answeredYes("Auto withdraw Bitcoin? (y/n): "):

--- a/bitcoin_dca/secret.py
+++ b/bitcoin_dca/secret.py
@@ -114,6 +114,9 @@ class Secret:
         with open("bitcoin_dca.secrets", "r") as f:
             secret_version = f.readline()
             if secret_version != SECRET_VERSION:
+                Logger.error(
+                    f"Wrong secret version. Expected: '{SECRET_VERSION}'; Found: '{secret_version}'"
+                )
                 raise Exception(
                     "Secret version mismatch. Please create a new secret valut by `make update_secrets`"
                 )

--- a/bitcoin_dca/secret.py
+++ b/bitcoin_dca/secret.py
@@ -53,16 +53,16 @@ class Secret:
                 print()
                 break
 
-        # Init empty secrets
-        api_key = ""
-        api_secret = ""
-        passphrase = ""
-        master_public_key = ""
-        beginning_address = ""
-        gmail_password = ""
-        robinhood_user = ""
-        robinhood_password = ""
-        robinhood_totp = ""
+        # Init secrets with random strings
+        api_key = base64.b64encode(os.urandom(16))
+        api_secret = base64.b64encode(os.urandom(16))
+        passphrase = base64.b64encode(os.urandom(16))
+        master_public_key = base64.b64encode(os.urandom(16))
+        beginning_address = base64.b64encode(os.urandom(16))
+        gmail_password = base64.b64encode(os.urandom(16))
+        robinhood_user = base64.b64encode(os.urandom(16))
+        robinhood_password = base64.b64encode(os.urandom(16))
+        robinhood_totp = base64.b64encode(os.urandom(16))
 
         if Secret.answeredYes("DCA with Coinbase Pro? (y/n): "):
             passphrase = getpass.getpass("Your Coinbase Pro API passphrase: ")

--- a/bitcoin_dca/secret.py
+++ b/bitcoin_dca/secret.py
@@ -66,8 +66,8 @@ class Secret:
 
         if Secret.answeredYes("DCA with Coinbase Pro? (y/n): "):
             passphrase = getpass.getpass("Your Coinbase Pro API passphrase: ")
-            api_key = getpass.getpass("Your Coinbase Pro API key: ")
             api_secret = getpass.getpass("Your Coinbase Pro API secret: ")
+            api_key = getpass.getpass("Your Coinbase Pro API key: ")
             print("")
 
             if Secret.answeredYes("Auto withdraw Bitcoin? (y/n): "):

--- a/config_template.ini
+++ b/config_template.ini
@@ -1,6 +1,6 @@
 [COINBASE_PRO]
 # How many times you want to buy Bitcoin every day.
-DCA_TIMES_PER_DAY = 40
+DCA_TIMES_PER_DAY = 1
 # How many dollars of Bitcoin you want to buy on Coinbase Pro each time.
 DCA_USD_AMOUNT = 5
 # The minimum USDC balance to be kept on Coinbase Pro.
@@ -10,7 +10,7 @@ MIN_USDC_BALANCE = 0
 # How many times you want to buy Bitcoin every day.
 DCA_TIMES_PER_DAY = 1
 # How many dollars of Bitcoin you want to buy each time.
-DCA_USD_AMOUNT = 100
+DCA_USD_AMOUNT = 5
 
 
 [AUTO_WITHDRAWL]

--- a/config_template.ini
+++ b/config_template.ini
@@ -18,15 +18,6 @@ DCA_USD_AMOUNT = 5
 # it will auto withdraw Bitcoin base on provided MASTER_PUBLIC_KEY.
 # WITHDRAW_EVERY_X_BUY = 20
 
-# The master public key to derive BTC addresess for Bitcoin auto withdrawal.
-# Only addresses with empty balance wil be used, and each address will be used
-# only once.
-# MASTER_PUBLIC_KEY = zpub...
-
-# The beginning address that BTC auto withdraw to. If not set, the first address
-# derived from MASTER_PUBLIC_KEY will be used as the BEGINNING_ADDRESS.
-# BEGINNING_ADDRESS = bc1....
-
 
 [NOTIFICATION]
 # If GMAIL_USER_NAME is set, bitcoin-dca will send out daily summary email

--- a/scripts/scripting.md
+++ b/scripts/scripting.md
@@ -9,7 +9,7 @@ import getpass
 from bitcoin_dca.bitcoin_dca import BitcoinDCA
 passwd = getpass.getpass()
 
-bitcoin_dca = BitcoinDCA(False, passwd)
+bitcoin_dca = BitcoinDCA(True, passwd)
 ```
 
 # Use Robinhood class


### PR DESCRIPTION
1. Move master public key and beginning address from config.ini to the secrets vault and encrypt them.
2. Init the secrets with random strings to avoid the vulnerability of "known plaintext attack".
3. Add versioning for secrets vault.
4. Fix sometimes unable to save the order result to db when the order result status is still pending
5. Update the default DCA config to $5 per day
