### PR TITLE
Set default logger level to INFO

### DIFF
--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -43,7 +43,7 @@ class BitcoinDCA:
         self.db_manager = DBManager()
         self.next_robinhood_buy_datetime = self.calcRobinhoodFirstBuyTime()
         if is_coinbase:
-            Logger.info("\n")
+            Logger.info("\n\n\n")
             Logger.info("----------------------")
             Logger.info("----------------------")
             Logger.info("Coinbase DCA started")
@@ -152,7 +152,6 @@ class BitcoinDCA:
         )
 
     def startCoinbaseDCA(self):
-        self.coinbase_pro.showBalance()
         Logger.info(
             f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
             f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase..."

--- a/bitcoin_dca/bitcoin_dca.py
+++ b/bitcoin_dca/bitcoin_dca.py
@@ -152,12 +152,6 @@ class BitcoinDCA:
         )
 
     def startCoinbaseDCA(self):
-        Logger.info(
-            f"We'll wait for {self.next_buy_datetime.strftime('%Y-%m-%d %H:%M:%S')} "
-            f"to buy ${default_config.dca_usd_amount} Bitcoin on Coinbase..."
-        )
-        Logger.info("")
-
         while True:
             self.waitForNextBuyTime()
 

--- a/bitcoin_dca/logger.py
+++ b/bitcoin_dca/logger.py
@@ -71,6 +71,6 @@ class Logger:
             handler.setFormatter(formatter)
             logger = logging.getLogger("BitcoinDCALogger")
             logger.addHandler(handler)
-            logger.setLevel(logging.DEBUG)
+            logger.setLevel(logging.INFO)
             Logger._logger = logger
         return Logger._logger


### PR DESCRIPTION
Use INFO as the default logger level, and remove duplicated unnecessary logs.