### PR TITLE
Fix a crash on "make update_secrets"

### DIFF
--- a/bitcoin_dca/secret.py
+++ b/bitcoin_dca/secret.py
@@ -54,15 +54,15 @@ class Secret:
                 break
 
         # Init secrets with random strings
-        api_key = base64.b64encode(os.urandom(16))
-        api_secret = base64.b64encode(os.urandom(16))
-        passphrase = base64.b64encode(os.urandom(16))
-        master_public_key = base64.b64encode(os.urandom(16))
-        beginning_address = base64.b64encode(os.urandom(16))
-        gmail_password = base64.b64encode(os.urandom(16))
-        robinhood_user = base64.b64encode(os.urandom(16))
-        robinhood_password = base64.b64encode(os.urandom(16))
-        robinhood_totp = base64.b64encode(os.urandom(16))
+        api_key = base64.b64encode(os.urandom(16)).decode('utf-8')
+        api_secret = base64.b64encode(os.urandom(16)).decode('utf-8')
+        passphrase = base64.b64encode(os.urandom(16)).decode('utf-8')
+        master_public_key = base64.b64encode(os.urandom(16)).decode('utf-8')
+        beginning_address = base64.b64encode(os.urandom(16)).decode('utf-8')
+        gmail_password = base64.b64encode(os.urandom(16)).decode('utf-8')
+        robinhood_user = base64.b64encode(os.urandom(16)).decode('utf-8')
+        robinhood_password = base64.b64encode(os.urandom(16)).decode('utf-8')
+        robinhood_totp = base64.b64encode(os.urandom(16)).decode('utf-8')
 
         if Secret.answeredYes("DCA with Coinbase Pro? (y/n): "):
             passphrase = getpass.getpass("Your Coinbase Pro API passphrase: ")


### PR DESCRIPTION
On updating the secrets, if we only set Robinhood credentials, the scripts crashes with below stack trace.

```
Traceback (most recent call last):
  File "./bitcoin_dca/setup.py", line 6, in <module>
    Secret.encryptAllSecrets()
  File "/root/bitcoin-dca/bitcoin_dca/secret.py", line 96, in encryptAllSecrets
    f.write(Secret.encrypt(key, api_key) + "\n")
  File "/root/bitcoin-dca/bitcoin_dca/secret.py", line 34, in encrypt
    return Fernet(encrypt_key).encrypt(content.encode()).decode("utf-8")
AttributeError: 'bytes' object has no attribute 'encode'
```

This PR makes the initial secrets actual strings instead of byte arrays.