### PR TITLE
Only use the available balance on Coinbase

### DIFF
--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -54,7 +54,7 @@ class CoinbasePro:
 
     @property
     def coinbase_usdc_account(self):
-        return self.convertRawAccount(self.getCoinbaseAccount("USDC"))
+        return self.convertRawCoinbaseAccount(self.getCoinbaseAccount("USDC"))
 
     @property
     def usd_account(self):
@@ -188,3 +188,7 @@ class CoinbasePro:
     @staticmethod
     def convertRawAccount(raw_account):
         return Account(id=raw_account["id"], balance=float(raw_account["available"]))
+
+    @staticmethod
+    def convertRawCoinbaseAccount(raw_account):
+        return Account(id=raw_account["id"], balance=float(raw_account["balance"]))

--- a/bitcoin_dca/coinbase_pro.py
+++ b/bitcoin_dca/coinbase_pro.py
@@ -187,4 +187,4 @@ class CoinbasePro:
 
     @staticmethod
     def convertRawAccount(raw_account):
-        return Account(id=raw_account["id"], balance=float(raw_account["balance"]))
+        return Account(id=raw_account["id"], balance=float(raw_account["available"]))


### PR DESCRIPTION
Balance not available (like on pending orders) should be excluded. Otherwise it may incorrectly trigger events like withdraw BTC when its balance has met the withdraw threshold.

Implement #47 