### PR TITLE
Support versatile scheduling with cron format

### DIFF
--- a/bitcoin_dca/config.py
+++ b/bitcoin_dca/config.py
@@ -21,6 +21,10 @@ class Config:
         return int(seconds_per_day / dca_times_per_day)
 
     @property
+    def dca_schedule(self):
+        return self.config["COINBASE_PRO"].get("DCA_SCHEDULE")
+
+    @property
     def dca_usd_amount(self):
         return self.config["COINBASE_PRO"].getint("DCA_USD_AMOUNT")
 
@@ -38,6 +42,10 @@ class Config:
         seconds_per_day = 24 * 3600
         # Convert dca times per day to dca frequency in seconds
         return int(seconds_per_day / dca_times_per_day)
+
+    @property
+    def robinhood_dca_schedule(self):
+        return self.config["ROBINHOOD"].get("DCA_SCHEDULE")
 
     @property
     def robinhood_dca_usd_amount(self):

--- a/config_template.ini
+++ b/config_template.ini
@@ -2,6 +2,10 @@
 # How many times you want to buy Bitcoin every day.
 DCA_TIMES_PER_DAY = 1
 
+# The purchase schedule defined by cron format (https://en.wikipedia.org/wiki/Cron).
+# If configured, DCA_TIMES_PER_DAY will be ignored.
+# DCA_SCHEDULE = 0 8 * * *
+
 # How many dollars of Bitcoin you want to buy on Coinbase Pro each time.
 DCA_USD_AMOUNT = 5
 
@@ -21,6 +25,10 @@ MIN_USDC_BALANCE = 0
 [ROBINHOOD]
 # How many times you want to buy Bitcoin every day.
 DCA_TIMES_PER_DAY = 1
+
+# The purchase schedule defined by cron format (https://en.wikipedia.org/wiki/Cron).
+# If configured, DCA_TIMES_PER_DAY will be ignored.
+# DCA_SCHEDULE = 0 8 * * *
 
 # How many dollars of Bitcoin you want to buy each time.
 DCA_USD_AMOUNT = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ robin-stocks==1.5.2
 sortedcontainers==2.1.0
 urllib3==1.24.2
 websocket-client==0.54.0
+croniter==1.0.1


### PR DESCRIPTION
Currently DCA scheduling has two problems:
- We can't set a fixed time to purchase, e.g. 9am daily. The purchasing time depends on when we run the script.
- We can't set purchase period longer than a day, like weekly, bi-weekly or monthly.

This PR addresses both problems by introducing cron format. For example, if we want to purchase at 8am everyday,  we just set `0 8 * * *` to `DCA_SCHEDULE` in `config.ini`. The detail of cron format can be found in this [wiki](https://en.wikipedia.org/wiki/Cron).

I think we can remove the support of `DCA_TIMES_PER_DAY` in the future.